### PR TITLE
Enabled rv32mi tests compilation, edited riscv_test.h

### DIFF
--- a/env/p/riscv_test.h
+++ b/env/p/riscv_test.h
@@ -37,20 +37,20 @@
 //   RVTEST_VECTOR_ENABLE;                                                 \
 //   .endm
 
-// #define RVTEST_RV64M                                                    \
-//   .macro init;                                                          \
-//   RVTEST_ENABLE_MACHINE;                                                \
-//   .endm
+#define RVTEST_RV64M                                                    \
+  .macro init;                                                          \
+  RVTEST_ENABLE_MACHINE;                                                \
+  .endm
 
 #define RVTEST_RV64S                                                    \
   .macro init;                                                          \
   /*RVTEST_ENABLE_SUPERVISOR;*/                                             \
   .endm
 
-// #define RVTEST_RV32M                                                    \
-//   .macro init;                                                          \
-//   RVTEST_ENABLE_MACHINE;                                                \
-//   .endm
+#define RVTEST_RV32M                                                    \
+  .macro init;                                                          \
+  RVTEST_ENABLE_MACHINE;                                                \
+  .endm
 
 #define RVTEST_RV32S                                                    \
   .macro init;                                                          \

--- a/isa/Makefile
+++ b/isa/Makefile
@@ -26,8 +26,8 @@ include $(src_dir)/rv32ui/Makefrag
 # include $(src_dir)/rv32uf/Makefrag
 # include $(src_dir)/rv32ud/Makefrag
 # include $(src_dir)/rv32uzfh/Makefrag
-include $(src_dir)/rv32si/Makefrag
-# include $(src_dir)/rv32mi/Makefrag
+# include $(src_dir)/rv32si/Makefrag
+include $(src_dir)/rv32mi/Makefrag
 
 default: all
 
@@ -86,8 +86,8 @@ $(eval $(call compile_template,rv32ui,-march=rv32g -mabi=ilp32))
 # $(eval $(call compile_template,rv32uf,-march=rv32g -mabi=ilp32))
 # $(eval $(call compile_template,rv32ud,-march=rv32g -mabi=ilp32))
 # $(eval $(call compile_template,rv32uzfh,-march=rv32g_zfh -mabi=ilp32))
-$(eval $(call compile_template,rv32si,-march=rv32g -mabi=ilp32))
-# $(eval $(call compile_template,rv32mi,-march=rv32g -mabi=ilp32))
+# $(eval $(call compile_template,rv32si,-march=rv32g -mabi=ilp32))
+$(eval $(call compile_template,rv32mi,-march=rv32g -mabi=ilp32))
 ifeq ($(XLEN),64)
 # $(eval $(call compile_template,rv64ui,-march=rv64g -mabi=lp64))
 # $(eval $(call compile_template,rv64uc,-march=rv64g -mabi=lp64))


### PR DESCRIPTION
- rv32mi were enabled in the Makefile,
- riscv_test.h was partially reverted to the original state, PASS and FAIL macros were edited to support our status handling